### PR TITLE
code style fixes, formatting, naming conventions

### DIFF
--- a/common.h
+++ b/common.h
@@ -1,25 +1,28 @@
-#ifndef COMMONSTRUCTS_H
-#define COMMONSTRUCTS_H
+#pragma once
+
 #include <stdbool.h>
-#include <time.h>
 #include <stdlib.h>
+#include <time.h>
 
-typedef enum { LIT, IDT } TType;
-typedef enum { TODO, EVENT, SCHED } TaskType;
-typedef enum { WD, MD, YD, IN } RepeatType;
-
+typedef enum { TOKEN_LIT = 0, TOKEN_IDENT } TokenType;
+typedef enum { TASK_TODO = 0, TASK_EVENT, TASK_SCHED } TaskType;
+typedef enum {
+  REPEATTYPE_WD = 0,
+  REPEATTYPE_MD,
+  REPEATTYPE_YD,
+  REPEATTYPE_IN
+} RepeatType;
 
 typedef struct {
   char pair[2];
-  TType tok_type;
+  TokenType tok_type;
   bool end;
 } DPair;
 
 typedef struct {
-  TType type;
+  TokenType type;
   char* token;
   bool end;
 } Tok;
 
 void* arrayInator(void* pointer, size_t memsize, size_t newsize);
-#endif

--- a/conv.c
+++ b/conv.c
@@ -1,13 +1,14 @@
+#include <regex.h>
 #include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <time.h>
-#include <regex.h>
+
 typedef struct tm Date;
 
 typedef struct {
   Date* array;
-  
+
   size_t len;
 } DateArray;
 
@@ -15,7 +16,7 @@ time_t* current = NULL;
 Date* current_local = NULL;
 
 regex_t regex;
-const char *format = "^([0-9]{2}|%)/[0-9]{2}/[0-9]{4}-([0-9]{2}|%)[:][0-9]{2}$";
+const char* format = "^([0-9]{2}|%)/[0-9]{2}/[0-9]{4}-([0-9]{2}|%)[:][0-9]{2}$";
 
 int compileRegex() {
   int result = regcomp(&regex, format, REG_EXTENDED);
@@ -36,24 +37,28 @@ bool isLeap(int year) {
   return (((year % 4 == 0) && (year % 100 != 0)) || (year % 400 == 0));
 }
 
-bool valiDate(Date in) {
+bool isDateValid(Date in) {
   if (in.tm_year > current_local->tm_year + 500 ||
       in.tm_year < current_local->tm_year - 500) {
     return false;
   }
+
   if (in.tm_mon < 0 || in.tm_mon > 12)
     return false;
+
   if (in.tm_mday < 0 || in.tm_mday > 31)
     return false;
+
   if (in.tm_mon == 2) {
     if (isLeap(in.tm_year + 1900))
       return (in.tm_mday <= 29);
     else
       return (in.tm_mday <= 28);
   }
-  if ( in.tm_mon == 4 || in.tm_mon == 6 || 
-        in.tm_mon == 9 || in.tm_mon == 11) 
-        return (in.tm_mday <= 30);
+
+  if (in.tm_mon == 4 || in.tm_mon == 6 || in.tm_mon == 9 || in.tm_mon == 11)
+    return (in.tm_mday <= 30);
+
   return true;
 }
 
@@ -61,14 +66,17 @@ Date convertStuff(char* src, char* format) {
   Date temp = {};
   char* splitters = "/^:";
   char* end_res = NULL;
-  if (verifyRepeatString(src) != 0){
+
+  if (verifyRepeatString(src) != 0) {
     printf("error conv.c line 63");
     exit(EXIT_FAILURE);
-  } 
+  }
+
   temp.tm_year -= 1900;
-  if (valiDate(temp) == false) {
+  if (isDateValid(temp) == false) {
     return (Date){};
   }
+
   return temp;
 }
 

--- a/lex.c
+++ b/lex.c
@@ -1,7 +1,7 @@
+#include "common.h"
 #include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include "common.h"
 /* removed useless def here*/
 DPair* findDelimP(char a, DPair* arr_delim) {
   do {
@@ -16,27 +16,35 @@ DPair* findDelimP(char a, DPair* arr_delim) {
 char* readTill(char** src_line, char end_char) {
   size_t bufsize = 1, offset = 0;
   char* buffer = NULL;
+
   if (*src_line == NULL)
     return NULL;
+
   while (**src_line != '\0' && **src_line != end_char) {
     if (offset == bufsize - 1) {
       bufsize *= 2;
       char* new_buf = realloc(buffer, bufsize);
+
       if (new_buf == NULL && buffer) {
         free(buffer);
         return NULL;
       }
+
       buffer = new_buf;
     }
+
     buffer[offset++] = **src_line;
     (*src_line)++;
   }
+
   if (offset < bufsize - 1) {
     char* new_buf = realloc(buffer, offset + 1);
+
     if (new_buf != NULL) {
       buffer = new_buf;
     }
   }
+
   buffer[offset] = '\0';
   return buffer;
 }
@@ -44,9 +52,11 @@ char* readTill(char** src_line, char end_char) {
 Tok nextTok(char** src_line, DPair* src_pair) {
   Tok local_tok;
   DPair* DelmP = NULL;
+
   while (**src_line == ' ') {
     (*src_line)++;
   }
+
   if ((DelmP = findDelimP(**src_line, src_pair)) != NULL) {
     (*src_line)++;
     local_tok.token = readTill(src_line, DelmP->pair[1]);
@@ -56,41 +66,52 @@ Tok nextTok(char** src_line, DPair* src_pair) {
     local_tok.token = readTill(src_line, ' ');
     local_tok.type = IDT;
   }
+
   return local_tok;
 }
 
 Tok* tokArr(char* src_str, DPair* src_pair) {
   Tok* list = NULL;
   size_t tok_size = sizeof(Tok), bufsize = 1, offset = 0;
+
   if (src_str == NULL) {
     return NULL;
   }
+
   while (*src_str != '\0') {
     if (offset == bufsize - 1) {
       bufsize *= 2;
+
       Tok* new_list = realloc(list, bufsize * tok_size);
       if (new_list == NULL && list) {
         free(list);
         return NULL;
       }
+
       list = new_list;
     }
+
     list[offset++] = nextTok(&src_str, src_pair);
   }
+
   if (offset < bufsize - 1) {
     Tok* new_list = realloc(list, offset * tok_size);
+
     if (new_list != NULL) {
       list = new_list;
     }
   }
+
   list[offset - 1].end = true;
   return list;
 }
 
 void deInit(Tok* array) {
   unsigned long index = 0;
+
   do {
     free(array[index++].token);
   } while (array[index - 1].end != true);
+
   free(array);
 }

--- a/lex.h
+++ b/lex.h
@@ -1,8 +1,6 @@
-#ifndef LEX_H
-#define LEX_H
+#pragma once
 
 #include "common.h"
+
 Tok* tokArr(char* src_line, DPair* src_pair);
 void deInit(Tok* array);
-
-#endif


### PR DESCRIPTION
fix code style, naming of idents and running `clang-format`